### PR TITLE
Allow custom Ollama model

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Example environment variables
+SYNC_DATABASE_URL=sqlite:///db.sqlite3
+SESSION_SECRET_KEY=a-secret-key
+PYTHONDONTWRITEBYTECODE=1
+ASYNC_DATABASE_URL=sqlite+aiosqlite:///./app.db
+NEXT_PUBLIC_API_URL=http://localhost:8000

--- a/.gitignore
+++ b/.gitignore
@@ -85,6 +85,8 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
+!/apps/backend/.env.sample
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -71,6 +71,18 @@ If you have any suggestions or feature requests, please feel free to open an iss
 
 Follow the instructions in the [SETUP.md](SETUP.md) file to set up the project locally. The setup script will install all the necessary dependencies and configure your environment.
 
+By default the setup pulls the `gemma3:4b` model. To use a different model set
+the `OLLAMA_MODEL` environment variable or pass `--ollama-model <model>` to
+`setup.sh`. You can also skip downloading a model altogether with
+`--skip-model-download` if you already have it installed.
+
+Example for using `llama3.2:latest` without downloading:
+
+```bash
+./setup.sh --ollama-model llama3.2:latest --skip-model-download
+npm run dev
+```
+
 The project is built using:
 
 - FastAPI for the backend.
@@ -78,8 +90,6 @@ The project is built using:
 - Ollama for local AI model serving.
 - Tailwind CSS for styling.
 - SQLite for the database.
-
-create a markdown table
 
 | Technology   | Info/Version                               |
 |--------------|---------------------------------------|

--- a/SETUP.md
+++ b/SETUP.md
@@ -13,7 +13,7 @@ This document provides cross-platform instructions to get the project up and run
 chmod +x setup.sh
 
 # 2. Configure your environment and install dependencies
-./setup.sh
+./setup.sh [--ollama-model <model>] [--skip-model-download]
 
 # 3. (Optional) Start the development server
 ./setup.sh --start-dev
@@ -21,6 +21,11 @@ chmod +x setup.sh
 make setup
 make run-dev
 ```
+
+### Additional options
+
+- `--ollama-model <model>` — override the default model (`gemma3:4b`)
+- `--skip-model-download` — don't pull the model if it's already installed
 
 ---
 
@@ -96,7 +101,7 @@ You can customize any variables in these files before or after bootstrapping.
    This will:
 
    - Verify/install prerequisites (`node`, `npm`, `python3`, `pip3`, `uv`, `ollama`)
-   - Pull the `gemma3:4b` model via Ollama
+   - Pull the model specified by `--ollama-model` (default `gemma3:4b`) via Ollama
    - Bootstrap root & backend `.env` files
    - Install Node.js deps (`npm ci`) at root and frontend
    - Sync Python deps in `apps/backend` via `uv sync`

--- a/apps/backend/.env.sample
+++ b/apps/backend/.env.sample
@@ -1,0 +1,4 @@
+# Example backend environment variables
+SYNC_DATABASE_URL=sqlite:///db.sqlite3
+SESSION_SECRET_KEY=a-secret-key
+ASYNC_DATABASE_URL=sqlite+aiosqlite:///./app.db

--- a/apps/backend/app/agent/manager.py
+++ b/apps/backend/app/agent/manager.py
@@ -8,7 +8,11 @@ from .providers.openai import OpenAIProvider, OpenAIEmbeddingProvider
 
 
 class AgentManager:
-    def __init__(self, strategy: str | None = None, model: str = "gemma3:4b") -> None:
+    def __init__(
+        self,
+        strategy: str | None = None,
+        model: str = os.getenv("OLLAMA_MODEL", "gemma3:4b"),
+    ) -> None:
         match strategy:
             case "md":
                 self.strategy = MDWrapper()

--- a/apps/backend/app/agent/providers/ollama.py
+++ b/apps/backend/app/agent/providers/ollama.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import ollama
 
 from typing import Any, Dict, List, Optional
@@ -11,7 +12,11 @@ logger = logging.getLogger(__name__)
 
 
 class OllamaProvider(Provider):
-    def __init__(self, model_name: str = "gemma3:4b", host: Optional[str] = None):
+    def __init__(
+        self,
+        model_name: str = os.getenv("OLLAMA_MODEL", "gemma3:4b"),
+        host: Optional[str] = None,
+    ):
         self.model = model_name
         self._client = ollama.Client(host=host) if host else ollama.Client()
 

--- a/setup.sh
+++ b/setup.sh
@@ -4,7 +4,7 @@
 # setup.sh - cross-platform setup for Resume Matcher
 #
 # Usage:
-#   ./setup.sh [--help] [--start-dev]
+#   ./setup.sh [--help] [--start-dev] [--ollama-model <model>] [--skip-model-download]
 #
 # Requirements:
 #   • Bash 4.4+ (for associative arrays)
@@ -29,15 +29,17 @@ esac
 #–– CLI help ––#
 usage() {
   cat <<EOF
-Usage: $0 [--help] [--start-dev]
+Usage: $0 [--help] [--start-dev] [--ollama-model <model>] [--skip-model-download]
 
 Options:
-  --help       Show this help message and exit
-  --start-dev  After setup completes, start the dev server (with graceful SIGINT handling)
+  --help                 Show this help message and exit
+  --start-dev            After setup completes, start the dev server (with graceful SIGINT handling)
+  --ollama-model <model> Model to use with Ollama (default: gemma3:4b)
+  --skip-model-download  Skip pulling the model via Ollama
 
 This script will:
   • Verify required tools: node, npm, python3, pip3, uv
-  • Install Ollama & pull gemma3:4b model
+  • Install Ollama & pull the specified model (default gemma3:4b)
   • Install root dependencies via npm ci
   • Bootstrap both root and backend .env files
   • Bootstrap backend venv and install Python deps via uv
@@ -46,12 +48,36 @@ EOF
 }
 
 START_DEV=false
-if [[ "${1:-}" == "--help" ]]; then
-  usage
-  exit 0
-elif [[ "${1:-}" == "--start-dev" ]]; then
-  START_DEV=true
-fi
+MODEL="gemma3:4b"
+SKIP_MODEL_DOWNLOAD=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --help)
+      usage
+      exit 0
+      ;;
+    --start-dev)
+      START_DEV=true
+      shift
+      ;;
+    --ollama-model)
+      MODEL="$2"
+      shift 2
+      ;;
+    --skip-model-download)
+      SKIP_MODEL_DOWNLOAD=true
+      shift
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+export OLLAMA_MODEL="${OLLAMA_MODEL:-$MODEL}"
 
 #–– Logging helpers ––#
 info()    { echo -e "ℹ  $*"; }
@@ -120,12 +146,16 @@ if ! command -v ollama &> /dev/null; then
   success "Ollama installed"
 fi
 
-if ! ollama list | grep -q 'gemma3:4b'; then
-  info "Pulling gemma3:4b model…"
-  ollama pull gemma3:4b || error "Failed to pull gemma3:4b"
-  success "gemma3:4b model ready"
+if [[ "$SKIP_MODEL_DOWNLOAD" == false ]]; then
+  if ! ollama list | grep -q "$OLLAMA_MODEL"; then
+    info "Pulling $OLLAMA_MODEL model…"
+    ollama pull "$OLLAMA_MODEL" || error "Failed to pull $OLLAMA_MODEL"
+    success "$OLLAMA_MODEL model ready"
+  else
+    info "$OLLAMA_MODEL model already present—skipping"
+  fi
 else
-  info "gemma3:4b model already present—skipping"
+  info "Skipping model download as requested"
 fi
 
 #–– 3. Bootstrap root .env ––#


### PR DESCRIPTION
## Summary
- support `--ollama-model` and `--skip-model-download` in `setup.sh`
- read `OLLAMA_MODEL` env var in agent manager and provider
- document new options in README and SETUP guide
- add sample env files
- adjust `.gitignore`

## Testing
- `python3 -m py_compile apps/backend/app/agent/manager.py apps/backend/app/agent/providers/ollama.py`
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_686e5d45b5e88325aff2060b34b1fa12