### PR TITLE
Use llama3.2 model by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ If you have any suggestions or feature requests, please feel free to open an iss
 
 Follow the instructions in the [SETUP.md](SETUP.md) file to set up the project locally. The setup script will install all the necessary dependencies and configure your environment.
 
-By default the setup pulls the `gemma3:4b` model. To use a different model set
+By default the setup pulls the `llama3.2:latest` model. To use a different model set
 the `OLLAMA_MODEL` environment variable or pass `--ollama-model <model>` to
 `setup.sh`. You can also skip downloading a model altogether with
 `--skip-model-download` if you already have it installed.

--- a/SETUP.md
+++ b/SETUP.md
@@ -22,9 +22,9 @@ make setup
 make run-dev
 ```
 
-### Additional options
+-### Additional options
 
-- `--ollama-model <model>` — override the default model (`gemma3:4b`)
+- `--ollama-model <model>` — override the default model (`llama3.2:latest`)
 - `--skip-model-download` — don't pull the model if it's already installed
 
 ---
@@ -101,7 +101,7 @@ You can customize any variables in these files before or after bootstrapping.
    This will:
 
    - Verify/install prerequisites (`node`, `npm`, `python3`, `pip3`, `uv`, `ollama`)
-   - Pull the model specified by `--ollama-model` (default `gemma3:4b`) via Ollama
+   - Pull the model specified by `--ollama-model` (default `llama3.2:latest`) via Ollama
    - Bootstrap root & backend `.env` files
    - Install Node.js deps (`npm ci`) at root and frontend
    - Sync Python deps in `apps/backend` via `uv sync`

--- a/apps/backend/app/agent/manager.py
+++ b/apps/backend/app/agent/manager.py
@@ -11,7 +11,7 @@ class AgentManager:
     def __init__(
         self,
         strategy: str | None = None,
-        model: str = os.getenv("OLLAMA_MODEL", "gemma3:4b"),
+        model: str = os.getenv("OLLAMA_MODEL", "llama3.2:latest"),
     ) -> None:
         match strategy:
             case "md":

--- a/apps/backend/app/agent/providers/ollama.py
+++ b/apps/backend/app/agent/providers/ollama.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 class OllamaProvider(Provider):
     def __init__(
         self,
-        model_name: str = os.getenv("OLLAMA_MODEL", "gemma3:4b"),
+        model_name: str = os.getenv("OLLAMA_MODEL", "llama3.2:latest"),
         host: Optional[str] = None,
     ):
         self.model = model_name

--- a/apps/backend/app/services/job_service.py
+++ b/apps/backend/app/services/job_service.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 class JobService:
     def __init__(self, db: AsyncSession):
         self.db = db
-        self.json_agent_manager = AgentManager(model="gemma3:4b")
+        self.json_agent_manager = AgentManager(model="llama3.2:latest")
 
     async def create_and_store_job(self, job_data: dict) -> List[str]:
         """

--- a/apps/backend/app/services/resume_service.py
+++ b/apps/backend/app/services/resume_service.py
@@ -24,7 +24,7 @@ class ResumeService:
     def __init__(self, db: AsyncSession):
         self.db = db
         self.md = MarkItDown(enable_plugins=False)
-        self.json_agent_manager = AgentManager(model="gemma3:4b")
+        self.json_agent_manager = AgentManager(model="llama3.2:latest")
 
     async def convert_and_store_resume(
         self, file_bytes: bytes, file_type: str, filename: str, content_type: str = "md"

--- a/setup.sh
+++ b/setup.sh
@@ -34,12 +34,12 @@ Usage: $0 [--help] [--start-dev] [--ollama-model <model>] [--skip-model-download
 Options:
   --help                 Show this help message and exit
   --start-dev            After setup completes, start the dev server (with graceful SIGINT handling)
-  --ollama-model <model> Model to use with Ollama (default: gemma3:4b)
+  --ollama-model <model> Model to use with Ollama (default: llama3.2:latest)
   --skip-model-download  Skip pulling the model via Ollama
 
 This script will:
   • Verify required tools: node, npm, python3, pip3, uv
-  • Install Ollama & pull the specified model (default gemma3:4b)
+  • Install Ollama & pull the specified model (default llama3.2:latest)
   • Install root dependencies via npm ci
   • Bootstrap both root and backend .env files
   • Bootstrap backend venv and install Python deps via uv
@@ -48,7 +48,7 @@ EOF
 }
 
 START_DEV=false
-MODEL="gemma3:4b"
+MODEL="llama3.2:latest"
 SKIP_MODEL_DOWNLOAD=false
 
 while [[ $# -gt 0 ]]; do


### PR DESCRIPTION
## Summary
- default to `llama3.2:latest` for resume parsing instead of `gemma3:4b`
- update README and setup docs
- update setup script description

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc' because dependencies are not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686eaba67d488325b9ad48633f76ab6d